### PR TITLE
Fixed .gitignore, updated package.json, add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 __pychache
-.py[cod]
+*.py[cod]
 node_modules/
 frontend/bower_components/
+*.db
+package-lock.json
+seed_cache.txt

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,11 @@
+with import <nixpkgs> {};
+stdenv.mkDerivation rec {
+  name = "env";
+  env = buildEnv { name = name; paths = buildInputs; };
+  buildInputs = [
+    python
+    python27Packages.python-Levenshtein
+    python27Packages.requests
+    nodejs
+  ];
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "ejs": "^1.0.0",
     "express": "^4.4.5",
-    "sqlite3": "^2.2.3"
+    "sqlite3": "^4.1.0",
+    "bower": "^1.8.8"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This pull request includes three small changes:

- Fixed .gitignore - It wasn't properly excluding .pyc and other files.

- Updated package.json - It was using an outdated version of sqlite3, and it was missing bower.

- Added default.nix - File helpful for installing some dependencies on platforms where [Nix](https://nixos.org/nix/) is supported.